### PR TITLE
No need to set foundValues more than only needed

### DIFF
--- a/src/org/alex859/codility/Covering.java
+++ b/src/org/alex859/codility/Covering.java
@@ -10,11 +10,10 @@ public class Covering {
         
         for(int i=0;i<N;i++){
         	if(foundValues[A[i]]==0){
-        		//i found an new value, this could be a solution
+        		//i found a new value, this could be a solution
         		P=i;
+		       	foundValues[A[i]]=1;
         	}
-        	
-        	foundValues[A[i]]++;
         }
         
         return P;


### PR DESCRIPTION
It would affect minor performance while adding up the certain found values. For example, if a byte item with a picture could have many duplicate values like this:
A[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,0,0,0,0,0,1,1,0,0,0,0,0,0,]

The change proposed will reduce the unnecessary and un-used variable changes in your code, boosting the efficiency when it comes to a very large input. 
And 1 minor typo correction in the comment.
